### PR TITLE
Fix 'evaluation warning: ... buildGoModule: specify CGO_ENABLED with env.CGO_ENABLED instead.'

### DIFF
--- a/pkgs/infrastructure-agent.nix
+++ b/pkgs/infrastructure-agent.nix
@@ -24,7 +24,7 @@ buildGoModule rec {
     "-X main.gitCommit=${src.rev}"
   ];
 
-  CGO_ENABLED = if stdenv.hostPlatform.isDarwin then "1" else "0";
+  env.CGO_ENABLED = if stdenv.hostPlatform.isDarwin then "1" else "0";
 
   subPackages = [
     "cmd/newrelic-infra"

--- a/pkgs/nr-otel-collector/default.nix
+++ b/pkgs/nr-otel-collector/default.nix
@@ -25,7 +25,7 @@ buildGoModule {
   # The TestGenerateAndCompile tests download new dependencies for a modified go.mod. Nix doesn't allow network access so skipping.
   checkFlags = [ "-skip TestValidateConfigs" ];
 
-  CGO_ENABLED = "0";
+  env.CGO_ENABLED = "0";
 
   meta = with lib; {
     description = "The New Relic distribution of the OpenTelemetry Collector";

--- a/pkgs/ocb.nix
+++ b/pkgs/ocb.nix
@@ -18,7 +18,7 @@ buildGoModule rec {
   vendorHash = "sha256-MTwD9xkrq3EudppLSoONgcPCBWlbSmaODLH9NtYgVOk=";
 
   GOFLAGS = [ "-trimpath" ];
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
   ldflags = [
     "-s"
     "-w"


### PR DESCRIPTION
I'm using your module in one of my servers and I started to see following error recently:
```
evaluation warning: /nix/store/1dyb7shmrf9v3xy5g2y7sajl5hhcppjd-source/pkgs/infrastructure-agent.nix:36: buildGoModule: specify CGO_ENABLED with env.CGO_ENABLED instead.
```

This should fix it 👍